### PR TITLE
added pptx and pptm reader

### DIFF
--- a/llama_index/readers/file/base.py
+++ b/llama_index/readers/file/base.py
@@ -22,6 +22,8 @@ DEFAULT_FILE_READER_CLS: Dict[str, Type[BaseReader]] = {
     ".pdf": PDFReader,
     ".docx": DocxReader,
     ".pptx": PptxReader,
+    ".ppt": PptxReader,
+    ".pptm": PptxReader,
     ".jpg": ImageReader,
     ".png": ImageReader,
     ".jpeg": ImageReader,


### PR DESCRIPTION
# Description

The default python pptx library can be used to load .ppt and .pptm extensions as well, the following commit will load powerpoint presentations with .ppt and .pptm extensions.

Fixes # (issue)

Changes to DEFAULT_FILE_READER_CLS of SimpleDirectory reader

# How Has This Been Tested?

Tested on ".ppt" and ".pptm" files

# Suggested Checklist:

- [ ] I have performed a self-review of my own code
